### PR TITLE
Remove hardcoded rules about rcl_interfaces message types

### DIFF
--- a/rmw_fastrtps_cpp/src/MessageTypeSupport.cpp
+++ b/rmw_fastrtps_cpp/src/MessageTypeSupport.cpp
@@ -14,9 +14,6 @@ MessageTypeSupport::MessageTypeSupport(const rosidl_typesupport_introspection_cp
     assert(members);
     members_ = members;
 
-    if(strcmp(members->package_name_, "rcl_interfaces") == 0 && strcmp(members->message_name_, "ParameterEvent") == 0)
-        typeTooLarge_ = true;
-
     std::string name = std::string(members->package_name_) + "::msg::dds_::" + members->message_name_ + "_";
     setName(name.c_str());
 

--- a/rmw_fastrtps_cpp/src/ServiceTypeSupport.cpp
+++ b/rmw_fastrtps_cpp/src/ServiceTypeSupport.cpp
@@ -16,10 +16,6 @@ RequestTypeSupport::RequestTypeSupport(const rosidl_typesupport_introspection_cp
     assert(members);
     members_ = members->request_members_;
 
-    if(strcmp(members->package_name_, "rcl_interfaces") == 0 && (strcmp(members->service_name_, "SetParameters") == 0 ||
-            strcmp(members->service_name_, "SetParametersAtomically") == 0))
-        typeTooLarge_ = true;
-
     std::string name = std::string(members->package_name_) + "::srv::dds_::" + members->service_name_ + "_Request_";
     setName(name.c_str());
 


### PR DESCRIPTION
There are some hardcoded rules that disable parameter-related rcl_interfaces types by setting `typeTooLarge_`, which should cause an exception in serialization:

https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/blob/master/rmw_fastrtps_cpp/src/TypeSupport.cpp#L180-L182
https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/blob/master/rmw_fastrtps_cpp/src/TypeSupport.cpp#L327-L329
https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/blob/master/rmw_fastrtps_cpp/src/TypeSupport.cpp#L589

I would expect that with these rules the FastRTPS ROS 2 parameter examples should never work, which contradicts what we see on CI.

I'm currently doing some testing to see how this affects the behavior of the parameters examples on Linux with Release build type.
